### PR TITLE
修正了render_3d.set_occupancy的行为，更改了函数需求的变量

### DIFF
--- a/GUI/main_window.py
+++ b/GUI/main_window.py
@@ -67,10 +67,10 @@ class MainWindow(QWidget, Ui_Form):
         self.defect_lineEdit.setText('0')
         self.rel_tem_lineEdit.setText('300')
         self.rel_sys_comboBox.setCurrentIndex(0)
-        self.rel_tim_lineEdiT.setText('1')
+        self.rel_tim_lineEdiT.setText('0.002')
         self.Them_lineEdit.setText('5')
         self.Them_sys_comboBox.setCurrentIndex(0)
-        self.Them_tim_lineEdit.setText('1')
+        self.Them_tim_lineEdit.setText('0.005')
 
     def recommend_experiment_2(self):
         self.exp2_ele1_comboBox.setCurrentIndex(0)
@@ -84,10 +84,10 @@ class MainWindow(QWidget, Ui_Form):
         self.defect_lineEdit.setText('0')
         self.rel_tem_lineEdit.setText('300')
         self.rel_sys_comboBox.setCurrentIndex(0)
-        self.rel_tim_lineEdiT.setText('1')
+        self.rel_tim_lineEdiT.setText('0.002')
         self.Them_lineEdit.setText('5')
         self.Them_sys_comboBox.setCurrentIndex(0)
-        self.Them_tim_lineEdit.setText('1')
+        self.Them_tim_lineEdit.setText('0.005')
 
     def choose_page_0(self):
         self.exp1_ele1_comboBox.setCurrentIndex(-1)
@@ -270,16 +270,15 @@ class MainWindow(QWidget, Ui_Form):
         self.zon_tem_checkBox_2.setChecked(False)
         if self.painting_zoom.itemAt(1) != None:
             self.painting_zoom.itemAt(1).widget().deleteLater() # 删除温度条
-        if (not self.gap_checkBox_2.isChecked()) and (not self.vacan_checkBox_2.isChecked()):
+        if not self.gap_checkBox_2.isChecked():
             render_3d.clear_modifiers()
         else:
-            render_3d.set_occupancy()
+            render_3d.set_occupancy('data/lattice.lmp')
             
 
     def set_tempareture_display(self):
         from output.tempareture_color_bar import create_tem_color_bar
         self.gap_checkBox_2.setChecked(False)
-        self.vacan_checkBox_2.setChecked(False)
         if self.zon_tem_checkBox_2.isChecked() == False:
             render_3d.clear_modifiers()
             if self.painting_zoom.itemAt(1) != None:


### PR DESCRIPTION
修正后render_3d.set_occupancy()的文档：

`rederence_file`: 必须指定参照文件，指向未弛豫前文件；
`display_vacancy`: 显示缺陷(`determin_occupancy=1`)，会强制切换至显示参照文件，否则无法正常显示；
`determin_occupancy`: 指定occupancy，而不是大于等于2；